### PR TITLE
Global namespace / Early return

### DIFF
--- a/ReadonlyStructGenerator/ReadonlyStructGenerator.cs
+++ b/ReadonlyStructGenerator/ReadonlyStructGenerator.cs
@@ -34,57 +34,55 @@ namespace ReadonlyStructGenerator
             var compilation = context.Compilation.AddSyntaxTrees(
                 CSharpSyntaxTree.ParseText(SourceText.From(attributeSource, Encoding.UTF8), options));
             var attributeSymbol = compilation.GetTypeByMetadataName("ReadonlyStructGenerator.ReadonlyStructAttribute");
-            
+
             foreach (var candidate in receiver.CandidateStructs)
             {
                 var model = compilation.GetSemanticModel(candidate.SyntaxTree);
                 var typeSymbol = ModelExtensions.GetDeclaredSymbol(model, candidate);
                 var attribute = typeSymbol.GetAttributes().FirstOrDefault(ad =>
                     ad.AttributeClass.Equals(attributeSymbol, SymbolEqualityComparer.Default));
-                if(attribute is not null)
-                {
-                    var namespaceName = typeSymbol.ContainingNamespace.ToDisplayString();
-                    var structName = typeSymbol.Name;
-                    var properties = candidate.Members
-                        .OfType<PropertyDeclarationSyntax>()
-                        .Where(prop=>prop.AccessorList?.Accessors.Any(acc=>acc.Kind() == SyntaxKind.InitAccessorDeclaration)??false)
-                        .Select(prop => new { Type = prop.Type.ToString(), Name = prop.Identifier.Text });
+                if (attribute is null) continue;
+                var namespaceName = typeSymbol.ContainingNamespace.ToDisplayString();
+                var structName = typeSymbol.Name;
+                var properties = candidate.Members
+                    .OfType<PropertyDeclarationSyntax>()
+                    .Where(prop => prop.AccessorList?.Accessors.Any(acc => acc.Kind() == SyntaxKind.InitAccessorDeclaration) ?? false)
+                    .Select(prop => new { Type = prop.Type.ToString(), Name = prop.Identifier.Text });
 
-                    var isConstructorDeclared = candidate.Members.Any(mem => mem.Kind() == SyntaxKind.ConstructorDeclaration);
-                    var sb = new StringBuilder();
-                    static string ToCamelCase(string name) => name.Length == 1 ? name.ToLower() : name.Substring(0,1).ToLower() + name.Substring(1);
-                    var parameters = string.Join(",", properties.Select(p => p.Type + " " + ToCamelCase(p.Name)));
-                    var propNames = string.Join(",", properties.Select(p => p.Name));
-                    var argNames = string.Join(",", properties.Select(p => ToCamelCase(p.Name)));
-                    var otherArgNams = string.Join(",", properties.Select(p => "other." + p.Name));
-                    var sourceArgNames =  string.Join(",", properties.Select(p => "source." + p.Name));
-                    var toStringParam = string.Join(",", properties.Select(p => "{" + p.Name + "}"));
-                    sb.AppendLine($"#nullable enable");
-                    sb.AppendLine($"using System;");
-                    if (!typeSymbol.ContainingNamespace.IsGlobalNamespace)
-                    {
-                        sb.AppendLine($"namespace {namespaceName}");
-                        sb.AppendLine($"{{");
-                    }
-                    sb.AppendLine($"    readonly partial struct {structName} : IEquatable<{structName}>");
-                    sb.AppendLine($"    {{");
-                    if (!isConstructorDeclared)
-                    {
-                        sb.AppendLine($"        public {structName}({parameters}) => ({propNames}) = ({argNames});");
-                    }
-                    sb.AppendLine($"        public bool Equals({structName} other) => ({propNames}) == ({otherArgNams});");
-                    sb.AppendLine($"        public override bool Equals(object? obj) => (obj is {structName} other) && Equals(other);");
-                    sb.AppendLine($"        public override int GetHashCode() => HashCode.Combine({propNames});");
-                    sb.AppendLine($"        public static bool operator ==({structName} left, {structName} right) => left.Equals(right);");
-                    sb.AppendLine($"        public static bool operator !=({structName} left, {structName} right) => !(left == right);");
-                    sb.AppendLine($"        public override string ToString() => $\"{{nameof({structName})}}({toStringParam})\";");
-                    sb.AppendLine($"    }}");
-                    if (!typeSymbol.ContainingNamespace.IsGlobalNamespace)
-                    {
-                        sb.AppendLine($"}}");
-                    }
-                    context.AddSource($"{structName}_generated.cs", SourceText.From(sb.ToString(), Encoding.UTF8));
+                var isConstructorDeclared = candidate.Members.Any(mem => mem.Kind() == SyntaxKind.ConstructorDeclaration);
+                var sb = new StringBuilder();
+                static string ToCamelCase(string name) => name.Length == 1 ? name.ToLower() : name.Substring(0, 1).ToLower() + name.Substring(1);
+                var parameters = string.Join(",", properties.Select(p => p.Type + " " + ToCamelCase(p.Name)));
+                var propNames = string.Join(",", properties.Select(p => p.Name));
+                var argNames = string.Join(",", properties.Select(p => ToCamelCase(p.Name)));
+                var otherArgNams = string.Join(",", properties.Select(p => "other." + p.Name));
+                var sourceArgNames = string.Join(",", properties.Select(p => "source." + p.Name));
+                var toStringParam = string.Join(",", properties.Select(p => "{" + p.Name + "}"));
+                sb.AppendLine($"#nullable enable");
+                sb.AppendLine($"using System;");
+                if (!typeSymbol.ContainingNamespace.IsGlobalNamespace)
+                {
+                    sb.AppendLine($"namespace {namespaceName}");
+                    sb.AppendLine($"{{");
                 }
+                sb.AppendLine($"    readonly partial struct {structName} : IEquatable<{structName}>");
+                sb.AppendLine($"    {{");
+                if (!isConstructorDeclared)
+                {
+                    sb.AppendLine($"        public {structName}({parameters}) => ({propNames}) = ({argNames});");
+                }
+                sb.AppendLine($"        public bool Equals({structName} other) => ({propNames}) == ({otherArgNams});");
+                sb.AppendLine($"        public override bool Equals(object? obj) => (obj is {structName} other) && Equals(other);");
+                sb.AppendLine($"        public override int GetHashCode() => HashCode.Combine({propNames});");
+                sb.AppendLine($"        public static bool operator ==({structName} left, {structName} right) => left.Equals(right);");
+                sb.AppendLine($"        public static bool operator !=({structName} left, {structName} right) => !(left == right);");
+                sb.AppendLine($"        public override string ToString() => $\"{{nameof({structName})}}({toStringParam})\";");
+                sb.AppendLine($"    }}");
+                if (!typeSymbol.ContainingNamespace.IsGlobalNamespace)
+                {
+                    sb.AppendLine($"}}");
+                }
+                context.AddSource($"{structName}_generated.cs", SourceText.From(sb.ToString(), Encoding.UTF8));
             }
         }
 

--- a/ReadonlyStructGenerator/ReadonlyStructGenerator.cs
+++ b/ReadonlyStructGenerator/ReadonlyStructGenerator.cs
@@ -61,8 +61,11 @@ namespace ReadonlyStructGenerator
                     var toStringParam = string.Join(",", properties.Select(p => "{" + p.Name + "}"));
                     sb.AppendLine($"#nullable enable");
                     sb.AppendLine($"using System;");
-                    sb.AppendLine($"namespace {namespaceName}");
-                    sb.AppendLine($"{{");
+                    if (!typeSymbol.ContainingNamespace.IsGlobalNamespace)
+                    {
+                        sb.AppendLine($"namespace {namespaceName}");
+                        sb.AppendLine($"{{");
+                    }
                     sb.AppendLine($"    readonly partial struct {structName} : IEquatable<{structName}>");
                     sb.AppendLine($"    {{");
                     if (!isConstructorDeclared)
@@ -76,7 +79,10 @@ namespace ReadonlyStructGenerator
                     sb.AppendLine($"        public static bool operator !=({structName} left, {structName} right) => !(left == right);");
                     sb.AppendLine($"        public override string ToString() => $\"{{nameof({structName})}}({toStringParam})\";");
                     sb.AppendLine($"    }}");
-                    sb.AppendLine($"}}");
+                    if (!typeSymbol.ContainingNamespace.IsGlobalNamespace)
+                    {
+                        sb.AppendLine($"}}");
+                    }
                     context.AddSource($"{structName}_generated.cs", SourceText.From(sb.ToString(), Encoding.UTF8));
                 }
             }


### PR DESCRIPTION
* Global namespace
* Early return

[グローバル名前空間](https://ufcpp.net/study/csharp/sp_namespace.html#global)の場合は``namespace * {``をなくしました。
その場合はインデントがおかしくなりますが、そこは放置しています。

``if(attribute is not null)``に違和感があったので、``if(attribute is null) continue;``にしました。